### PR TITLE
make the RazorMovie project break the build when vulnerable packages are used

### DIFF
--- a/RazorMovie/RazorMovie.csproj
+++ b/RazorMovie/RazorMovie.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	<WarningsAsErrors>$(WarningsAsErrors);NU1901;NU1902;NU1903;NU1904;</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Setting this makes demos about nuget package updated + user in the loop scenarios easier to trigger, because the package updates _must_ be resolved to continue the upgrade process.